### PR TITLE
Add nearby entity response feature

### DIFF
--- a/src/main/java/com/owlmaddie/chat/EntityChatData.java
+++ b/src/main/java/com/owlmaddie/chat/EntityChatData.java
@@ -566,6 +566,9 @@ public class EntityChatData {
                     this.previousMessages.set(this.previousMessages.size() - 1,
                             new ChatMessage(result.getOriginalMessage(), ChatDataManager.ChatSender.ASSISTANT, player.getDisplayName().getString()));
                         player.server.getPlayerManager().broadcast(Text.of("<" + entity.getCustomName().getString() + " the " +entity.getType().getName().getString() + "> " + cleanedMessage), false);
+
+                        // Nearby entities may respond to this message
+                        ServerPackets.generate_nearby_chat(userLanguage, player, entity, cleanedMessage);
                 } else {
                     // No valid LLM response
                     throw new RuntimeException(ChatGPTRequest.lastErrorMessage);

--- a/src/main/java/com/owlmaddie/network/ServerPackets.java
+++ b/src/main/java/com/owlmaddie/network/ServerPackets.java
@@ -334,6 +334,24 @@ public class ServerPackets {
         chatData.generateMessage(userLanguage, player, message, is_auto_message, isFromChat);
     }
 
+    // Trigger nearby entities to potentially respond to a message
+    public static void generate_nearby_chat(String userLanguage, ServerPlayerEntity player, MobEntity speakingEntity, String message) {
+        ServerWorld world = (ServerWorld) speakingEntity.getWorld();
+        double radius = 8.0;
+        for (Entity entity : world.iterateEntities()) {
+            if (entity instanceof MobEntity other && entity != speakingEntity) {
+                if (speakingEntity.distanceTo(other) <= radius) {
+                    EntityChatData otherData = ChatDataManager.getServerInstance().getOrCreateChatData(other.getUuidAsString());
+                    if (!otherData.characterSheet.isEmpty() && Math.random() < 0.5) {
+                        String sourceName = speakingEntity.getDisplayName().getString();
+                        String userMessage = "<" + sourceName + " said: " + message + ">";
+                        generate_chat(userLanguage, otherData, player, other, userMessage, true, false);
+                    }
+                }
+            }
+        }
+    }
+
     // Writing a Map<String, PlayerData> to the buffer
     public static void writePlayerDataMap(PacketByteBuf buffer, Map<String, PlayerData> map) {
         buffer.writeInt(map.size()); // Write the size of the map


### PR DESCRIPTION
## Summary
- allow nearby entities to respond to new messages
- broadcast to nearby mobs within 8 blocks with a 50% chance

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*