### PR TITLE
Implement OpenAI action bridge

### DIFF
--- a/src/client/java/com/owlmaddie/player2/Player2APIService.java
+++ b/src/client/java/com/owlmaddie/player2/Player2APIService.java
@@ -98,4 +98,16 @@ public class Player2APIService {
             System.err.printf("Heartbeat Fail: %s",e.getMessage());
         }
     }
+
+    /**
+     * Send a chat completion request to the local LLM.
+     *
+     * @param requestBody JSON request body following the OpenAI chat completion
+     *                    schema.
+     * @return Map of JSON keys from the response.
+     * @throws Exception if the HTTP request fails.
+     */
+    public static Map<String, JsonElement> sendChatCompletion(JsonObject requestBody) throws Exception {
+        return sendRequest("/v1/chat/completions", true, requestBody);
+    }
 }

--- a/src/client/java/com/owlmaddie/player2/ai/AIAction.java
+++ b/src/client/java/com/owlmaddie/player2/ai/AIAction.java
@@ -1,0 +1,30 @@
+package com.owlmaddie.player2.ai;
+
+/**
+ * Represents a single action returned by the LLM.
+ */
+public class AIAction {
+    private final String name;
+    private final String arguments;
+
+    public AIAction(String name, String arguments) {
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public String toString() {
+        if (arguments != null && !arguments.isEmpty()) {
+            return name + "(" + arguments + ")";
+        }
+        return name;
+    }
+}

--- a/src/client/java/com/owlmaddie/player2/ai/AICommandBridge.java
+++ b/src/client/java/com/owlmaddie/player2/ai/AICommandBridge.java
@@ -1,0 +1,35 @@
+package com.owlmaddie.player2.ai;
+
+import java.util.List;
+
+/**
+ * Simple bridge that uses {@link OpenAIChatAI} to get actions and execute them.
+ * This is only a minimal example and would need to be expanded to actually
+ * perform Minecraft tasks.
+ */
+public class AICommandBridge {
+    private final OpenAIChatAI ai;
+
+    public AICommandBridge(OpenAIChatAI ai) {
+        this.ai = ai;
+    }
+
+    /**
+     * Send a chat message to the LLM and execute any returned actions.
+     */
+    public void handlePlayerChat(String message) {
+        String response = ai.getCompletion(message);
+        if (response == null || response.isEmpty()) {
+            return;
+        }
+        List<AIAction> actions = CommandParser.parseActions(response);
+        for (AIAction action : actions) {
+            executeAction(action);
+        }
+    }
+
+    private void executeAction(AIAction action) {
+        // Placeholder for actual integration with in-game commands.
+        System.out.println("[AICommandBridge] Executing action: " + action);
+    }
+}

--- a/src/client/java/com/owlmaddie/player2/ai/CommandParser.java
+++ b/src/client/java/com/owlmaddie/player2/ai/CommandParser.java
@@ -1,0 +1,24 @@
+package com.owlmaddie.player2.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility to parse simple <ACTION args> tokens from LLM output.
+ */
+public class CommandParser {
+    private static final Pattern ACTION_PATTERN = Pattern.compile("<([A-Z_]+)([^>]*)>");
+
+    public static List<AIAction> parseActions(String input) {
+        List<AIAction> actions = new ArrayList<>();
+        Matcher matcher = ACTION_PATTERN.matcher(input);
+        while (matcher.find()) {
+            String name = matcher.group(1).trim();
+            String args = matcher.group(2) != null ? matcher.group(2).trim() : "";
+            actions.add(new AIAction(name, args));
+        }
+        return actions;
+    }
+}

--- a/src/client/java/com/owlmaddie/player2/ai/OpenAIChatAI.java
+++ b/src/client/java/com/owlmaddie/player2/ai/OpenAIChatAI.java
@@ -1,0 +1,48 @@
+package com.owlmaddie.player2.ai;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.owlmaddie.player2.Player2APIService;
+
+import java.util.Map;
+
+/**
+ * Helper for interacting with the local OpenAI compatible endpoint.
+ */
+public class OpenAIChatAI {
+    private final String model;
+
+    public OpenAIChatAI(String model) {
+        this.model = model;
+    }
+
+    /**
+     * Send a single user message to the LLM and return the raw response text.
+     */
+    public String getCompletion(String message) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("model", model);
+        JsonArray messages = new JsonArray();
+        JsonObject m = new JsonObject();
+        m.addProperty("role", "user");
+        m.addProperty("content", message);
+        messages.add(m);
+        payload.add("messages", messages);
+
+        try {
+            Map<String, JsonElement> resp = Player2APIService.sendChatCompletion(payload);
+            if (resp.containsKey("choices")) {
+                JsonArray choices = resp.get("choices").getAsJsonArray();
+                if (!choices.isEmpty()) {
+                    JsonObject first = choices.get(0).getAsJsonObject();
+                    JsonObject msg = first.getAsJsonObject("message");
+                    return msg.get("content").getAsString();
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Chat completion failed: " + e.getMessage());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- expose `sendChatCompletion` in `Player2APIService`
- add simple OpenAI chat helper
- parse `<ACTION>` tokens from model output
- basic AI command bridge that prints the parsed actions

## Testing
- `./gradlew test` *(fails: Could not download dependencies)*